### PR TITLE
README tiny edit in Usage example

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -36,12 +36,12 @@ Evergreen assumes a file and directory structure, place all your javascript
 code inside ./public and all spec files inside ./spec/javascripts. All spec
 files should end in _spec.js. For example:
 
-    public/widget.js
+    public/javascripts/widget.js
     spec/javascripts/widget_spec.js
 
 You can require files from the public directory inside your spec file:
 
-    require('/widget.js')
+    require('/javascripts/widget.js')
 
     describe('a widget', function() {
       ...


### PR DESCRIPTION
In the usage example, require loads from public/javascripts/ rather than public, as it is the standard Rails directory for js.

I am kind of new to js and jasmine. It took me a while - 1 pomodoro ;) -to understand that "Error: ReferenceError: ProofOfConcept is not defined"

require function does not throw an error when it can not find the js.

My edit in the README will make it easier to not to forget the /javascripts bit for newbies
