### PR TITLE
Fixes evergreen/rails to work out of the box in an engine.

### DIFF
--- a/evergreen.gemspec
+++ b/evergreen.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', ['~> 2.0'])
   s.add_development_dependency('capybara-webkit', ['>= 1.0.0.beta4'])
   s.add_development_dependency('therubyracer', ['~> 0.9'])
+  s.add_development_dependency('rails', ['~> 3.1.1'])
 end

--- a/lib/evergreen/rails.rb
+++ b/lib/evergreen/rails.rb
@@ -7,6 +7,7 @@ module Evergreen
       initializer 'evergreen.config' do
         Evergreen.application = Rails.application
         Evergreen.root = Rails.root
+        Evergreen.root = File.expand_path('../../', Evergreen.root) if Rails.application.engine_name == 'dummy_application'
         Evergreen.mounted_at = "/evergreen"
       end
     end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'rails/all'
+require 'evergreen/rails'
+
+class TestApplication < Rails::Engine
+  def self.new; super end
+end
+
+describe Evergreen::Railtie do
+  describe :evergreen_config_initializer do
+    subject { Evergreen::Railtie.initializers.first.block }
+
+    let(:test_app) { TestApplication.new }
+    let(:test_engine) { TestEngine.new }
+
+    before :each do
+      Rails.stub(:application).and_return(test_app)
+      Rails.stub(:root).and_return('/foo/bar/foobar')
+      test_app.stub(:engine_name).and_return('some_app')
+    end
+
+    it "should set the mounted_at to /evergreen" do
+      subject.call
+
+      Evergreen.mounted_at.should == '/evergreen'
+    end
+
+    it "should set the application to the rails application" do
+      subject.call
+
+      Evergreen.application.should == test_app
+    end
+
+    it "should set the root to the rails root" do
+      subject.call
+
+      Evergreen.root.should == '/foo/bar/foobar'
+    end
+
+    context "when running in an engine" do
+      before(:each) do
+        test_app.stub(:engine_name).and_return('dummy_application')
+      end
+
+      it "should set the root to the Rails root then up 2 directories" do
+        subject.call
+
+        Evergreen.root.should == '/foo'
+      end
+    end
+  end
+end


### PR DESCRIPTION
In an engine, the normal behaviour is to place your tests in
spec/javascripts or test/javascripts.

However, when the app is booted, the dummy app in spec/dummy or
test/dummy is booted, so Rails.root returns <engine_path>/spec/dummy.

In this case, we want evergreen to look at <engine_path>, so we go up
two levels from the Rails.root.

I've also added some tests for the rails.rb file, as there were none
before, and tests for this new functionality. Unfortunately it requires
rails to be a development dependency since we make use of Rails::Engine
and Rails::Application in the tests.

I couldn't find a better way to check if we're in an engine's dummy app
than to look at the #engine_name - this is not great but there is no
other way I could find.

Also, I couldn't get the entire test suite to pass after a fresh
checkout, so I'm not sure if this affects anything else.
