### PR TITLE
Fix to make sure user specific configuration is loaded before the

### DIFF
--- a/lib/evergreen.rb
+++ b/lib/evergreen.rb
@@ -35,6 +35,15 @@ module Evergreen
         config.mounted_at = ""
       end
     end
+
+    def load_user_config!
+      paths = [
+        File.expand_path("config/evergreen.rb", root),
+        File.expand_path(".evergreen", root),
+        "#{ENV["HOME"]}/.evergreen"
+      ]
+      paths.each { |path| load(path) if File.exist?(path) }
+    end
   end
 end
 

--- a/lib/evergreen/application.rb
+++ b/lib/evergreen/application.rb
@@ -7,6 +7,8 @@ module Evergreen
     end
 
     def build_application
+      Evergreen.load_user_config!
+
       Rack::Builder.new do
         instance_eval(&Evergreen.extensions) if Evergreen.extensions
 

--- a/lib/evergreen/suite.rb
+++ b/lib/evergreen/suite.rb
@@ -3,13 +3,7 @@ module Evergreen
     attr_reader :runner, :server, :driver, :application
 
     def initialize
-      paths = [
-        File.expand_path("config/evergreen.rb", root),
-        File.expand_path(".evergreen", root),
-        "#{ENV["HOME"]}/.evergreen"
-      ]
-      paths.each { |path| load(path) if File.exist?(path) }
-
+      Evergreen.load_user_config!
       @runner = Runner.new(self)
       @server = Server.new(self)
       @application = Evergreen.application


### PR DESCRIPTION
application is built.

We were having an issue where we were overriding public_dir in a
.evergreen file. When the server is booted, the application was being built
with the default settings.

When a new suite instance was created, the user config was being loaded,
but since the Evergreen.application instance was cached, its public_dir
setting was not getting updated.

I've move the user config loading to a load_user_config! method on
Evergreen, and called this before the application is built to make sure
the user config gets loaded first.
