### PR TITLE
attachEvent fixed for IE - onload should be used instead of load

### DIFF
--- a/lib/evergreen/views/run.erb
+++ b/lib/evergreen/views/run.erb
@@ -32,13 +32,18 @@
       <% @suite.templates.each do |template| %>
         Evergreen.templates[<%= template.name.to_json %>] = <%= template.escaped_contents %>;
       <% end %>
-      eventFunction = window.addEventListener ? 'addEventListener' : 'attachEvent';
-      window[eventFunction]('load', function() {
+      var jasmineExecute = function() {
         var jasmineEnv = jasmine.getEnv();
         jasmineEnv.addReporter(new jasmine.TrivialReporter());
         jasmineEnv.addReporter(new Evergreen.ReflectiveReporter());
         jasmineEnv.execute();
-      });
+      };
+      if (window.addEventListener) {
+        window.addEventListener("load", jasmineExecute, false);
+      }
+      else {
+        window.attachEvent("onload", jasmineExecute);
+      }
     })();
   // ]]>
 </script>


### PR DESCRIPTION
In context of https://github.com/jnicklas/evergreen/issues/40

It's a small fix for IE, because while using attachEvent one should use 'onload' event instead of 'load' (for other browsers).
