### PR TITLE
should load js files required in spec_helper.js before spec js files loaded

### DIFF
--- a/lib/evergreen/views/run.erb
+++ b/lib/evergreen/views/run.erb
@@ -6,6 +6,10 @@
   // <![CDATA[
       <%= render_spec(@coffee_spec_helper) if @coffee_spec_helper.exist? %>;
       <%= render_spec(@js_spec_helper) if @js_spec_helper.exist? %>;
+  // ]]>
+</script>
+<script type="text/javascript">
+  // <![CDATA[
       <% if @spec %>
         <%= render_spec(@spec) %>
       <% else %>


### PR DESCRIPTION
Here's my simple test case.

Given I have public/javascripts/hello.js which declares a variable:

```
var hello = 'hello';
```

And have spec_helper file like:

```
require('/javascripts/hello.js');
```

And here comes the hello_spec.js:

```
console.log(hello);
```

Then I run the spec in browser, I get an error 'ReferenceError: Can't find variable: hello'.

I find the rendered spec web runner has some html snippet like following:

```
<script type="text/javascript">
  // <![CDATA[
      ;
      require('/javascripts/hello.js');
      ;
      console.log(hello);
  // ]]>
</script>
```

Though hello.js is required at the very beginning, it is loaded after the test code executed.

Please check out my solution, I'm not sure if it affects anything else.
