### PR TITLE
Shutdown on ctrl-C.

### DIFF
--- a/lib/evergreen/server.rb
+++ b/lib/evergreen/server.rb
@@ -5,6 +5,7 @@ module Evergreen
     def serve
       server.boot
       Launchy.open(server.url(Evergreen.mounted_at.to_s + '/'))
+      trap('SIGINT') { puts 'Shutting down...' ; exit 0 }
       sleep
     end
 


### PR DESCRIPTION
Make `evergreen serve` exit on `^C`.

In my environment (rails 3.0.9, capybara 1.1.2, thin 1.3.1, evergreen 1.0.0, etc), the above wasn't happening. AFAICT, nothing but `kill -9` made it stop.

I was able to reproduce the un-SIGINT-able sleep by running this:

``` ruby
require 'capybara'
app = lambda do |env|
  [200, {'Content-type' => 'text/plain'}, 'ok']
end
server = Capybara::Server.new(app)
server.boot
#trap("SIGINT") { exit 0 }
puts server.url('/').inspect
sleep
puts 'done!'
```

Uncommenting the `trap` call makes `^C` work as expected.
