### PR TITLE
Drop support for 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 rvm:
- - 1.9.2
  - 1.9.3
  - ruby-head
 before_script:


### PR DESCRIPTION
Capybara requires a ruby version of at least 1.9.3, so we need to drop
support for 1.9.2
