### PR TITLE
bump version

### DIFF
--- a/lib/evergreen/version.rb
+++ b/lib/evergreen/version.rb
@@ -1,3 +1,3 @@
 module Evergreen
-  VERSION = '1.0.1'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
Bump version to 1.1.0
- Now uses Capybara 2.1
  - Update to readme docs for change in location of spec_helper.js
