### PR TITLE
Switch to poltegeist

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,9 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'pry'
+group :development, :test do
+  gem 'poltergeist'
+  gem 'phantomjs', :require => 'phantomjs/poltergeist'
+end
 
+gem 'pry'

--- a/evergreen.gemspec
+++ b/evergreen.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('rspec', ['~> 2.0'])
   s.add_development_dependency('rspec-its')
-  s.add_development_dependency('capybara-webkit')
   s.add_development_dependency('therubyracer', ['~> 0.9'])
   s.add_development_dependency('rake')
   s.add_development_dependency('coveralls')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,14 +5,14 @@ require 'evergreen'
 require 'rspec'
 
 require 'capybara/dsl'
-require 'capybara-webkit'
+require 'capybara/poltergeist'
 
 require 'pry'
 
 require 'coveralls'
 Coveralls.wear!
 
-TEST_DRIVER = :webkit
+TEST_DRIVER = :poltergeist
 
 Evergreen.root = File.expand_path('suite1', File.dirname(__FILE__))
 


### PR DESCRIPTION
With the many troubles we've had compiling the capybara-webkit gem, I
thought it best to remove it, as it is not necessary for this gem to be
devloped/used.

We've also seen some performance improvement on headless environments
using phantomjs with poltergeist on apps using evergreen.