### PR TITLE
Introduce noConflict for global JS methods

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -2,6 +2,7 @@
 
 {<img src="https://travis-ci.org/abepetrillo/evergreen.png" />}[http://travis-ci.org/abepetrillo/evergreen]
 {<img src="https://coveralls.io/repos/abepetrillo/evergreen/badge.png" alt="Coverage Status" />}[https://coveralls.io/r/abepetrillo/evergreen]
+{<img src="https://codeclimate.com/github/abepetrillo/evergreen/badges/gpa.svg" />}[https://codeclimate.com/github/abepetrillo/evergreen]
 
 "Because green is the new Blue(Ridge)"
 

--- a/lib/evergreen/resources/run.js
+++ b/lib/evergreen/resources/run.js
@@ -1,6 +1,8 @@
 if(!this.JSON){this.JSON={};}
 
-var Evergreen = {};
+var Evergreen = {
+  potentialConflicts: {}
+};
 
 Evergreen.dots = ""
 
@@ -35,16 +37,37 @@ beforeEach(function() {
   document.getElementById('test').innerHTML = "";
 });
 
-var template = function(name) {
+Evergreen.template = function(name) {
   beforeEach(function() {
     document.getElementById('test').innerHTML = Evergreen.templates[name]
   });
 };
 
-var require = function(file) {
+Evergreen.require = function(file) {
   document.write('<script type="text/javascript" src="' + file + '"></script>');
 };
 
-var stylesheet = function(file) {
+Evergreen.stylesheet = function(file) {
   document.write('<link rel="stylesheet" type="text/css" href="' + file + '"/>');
 };
+
+Evergreen.defineGlobalMethods = function(){
+  this.potentialConflicts['require'] = window['require']
+  this.potentialConflicts['template'] = window['template']
+  this.potentialConflicts['stylesheet'] = window['stylesheet']
+
+  window.require = Evergreen.require
+  window.template = Evergreen.template
+  window.stylesheet = Evergreen.stylesheet
+}
+
+
+
+//Tells Evergreen to namespace functions instead of potentially over-riding existing ones
+Evergreen.noConflict = function() {
+  window.require = this.potentialConflicts.require
+  window.template = this.potentialConflicts.template
+  window.stylesheet = this.potentialConflicts.stylesheet
+}
+
+Evergreen.defineGlobalMethods()

--- a/spec/meta_spec.rb
+++ b/spec/meta_spec.rb
@@ -46,4 +46,19 @@ describe Evergreen::Runner do
       it { is_expected.not_to pass }
     end
   end
+
+  context 'when noConflict is called via JS' do
+    before { Evergreen.root = File.expand_path('suite3', File.dirname(__FILE__)) }
+    let(:template) { 'awesome_spec.js' }
+    it 'does not over-ride existing methods in window' do
+      expect(subject).to pass
+    end
+
+    context 'and not using the Evergreen namespace' do
+      let(:template) { 'failing_spec.js' }
+      it 'fails' do
+        expect(subject).to_not pass
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,11 @@ Capybara.default_driver = TEST_DRIVER
 
 module EvergreenMatchers
   class PassSpec # :nodoc:
+
+    def description
+      'Successfull if the runner manages to pass all the JS specs'
+    end
+
     def matches?(actual)
       @actual = actual
       @runner = Evergreen::Runner.new(StringIO.new).spec_runner(@actual)

--- a/spec/suite3/public/foo.js
+++ b/spec/suite3/public/foo.js
@@ -1,0 +1,1 @@
+var something = "The Foo";

--- a/spec/suite3/spec/javascripts/awesome_spec.js
+++ b/spec/suite3/spec/javascripts/awesome_spec.js
@@ -1,0 +1,12 @@
+Evergreen.require('/foo.js');
+
+describe('awesome', function() {
+  Evergreen.template('foo.html');
+
+  it('requires public files', function() {
+    expect(something).toEqual('The Foo');
+  });
+  it('loads templates', function() {
+    expect(document.getElementById('foo').innerHTML).toEqual('The foo template');
+  });
+});

--- a/spec/suite3/spec/javascripts/failing_spec.js
+++ b/spec/suite3/spec/javascripts/failing_spec.js
@@ -1,0 +1,12 @@
+require('/foo.js');
+
+describe('awesome', function() {
+  template('foo.html');
+
+  it('requires public files', function() {
+    expect(something).toEqual('The Foo');
+  });
+  it('loads templates', function() {
+    expect(document.getElementById('foo').innerHTML).toEqual('The foo template');
+  });
+});

--- a/spec/suite3/spec/javascripts/helpers/spec_helper.js
+++ b/spec/suite3/spec/javascripts/helpers/spec_helper.js
@@ -1,0 +1,9 @@
+Evergreen.noConflict();
+
+require = function(file){
+  //console.log('custom require code')
+}
+
+template = function(file){
+  //console.log('custom template code')
+}

--- a/spec/suite3/spec/javascripts/templates/foo.html
+++ b/spec/suite3/spec/javascripts/templates/foo.html
@@ -1,0 +1,1 @@
+<div id="foo">The foo template</div>

--- a/spec/suite3/templates/foo.html
+++ b/spec/suite3/templates/foo.html
@@ -1,0 +1,1 @@
+<div id="foo">The foo template</div>


### PR DESCRIPTION
Attempting to support a noConflict option similar to jQuery's
noConflict. If Evergreen nukes a pre-existing method like `require`,
calling `Evergreen.noConflict()` will retrieve the old definition, and
the developer is required to use `Evergreen.require` instead of `require`

The code is pretty crude, but any sort of refactor seems to upset
poltergeist, so I'll get to refactoring this later

This should satisfy issue #17.