### PR TITLE
Configurable timeout

### DIFF
--- a/lib/evergreen.rb
+++ b/lib/evergreen.rb
@@ -17,7 +17,7 @@ module Evergreen
   autoload :Helper, 'evergreen/helper'
 
   class << self
-    attr_accessor :driver, :root, :application, :public_dir, :spec_dir, :template_dir, :helper_dir, :mounted_at
+    attr_accessor :driver, :root, :application, :public_dir, :spec_dir, :template_dir, :helper_dir, :mounted_at, :spec_timeout
 
     def configure
       yield self
@@ -32,6 +32,7 @@ module Evergreen
         config.template_dir = 'spec/javascripts/templates'
         config.helper_dir   = 'spec/javascripts/helpers'
         config.mounted_at   = ""
+        config.spec_timeout = 300
       end
     end
   end

--- a/lib/evergreen/runner.rb
+++ b/lib/evergreen/runner.rb
@@ -49,7 +49,7 @@ module Evergreen
 
           previous_results = ""
 
-          Evergreen.timeout(300) do
+          Evergreen.timeout(Evergreen.spec_timeout) do
             dots = session.evaluate_script('Evergreen.dots')
             io.print dots.sub(/^#{Regexp.escape(previous_results)}/, '')
             io.flush

--- a/lib/evergreen/runner.rb
+++ b/lib/evergreen/runner.rb
@@ -49,7 +49,7 @@ module Evergreen
 
           previous_results = ""
 
-          Evergreen.timeout(Evergreen.spec_timeout) do
+          Evergreen.timeout(Evergreen.spec_timeout, "#{spec.name} timed out!") do
             dots = session.evaluate_script('Evergreen.dots')
             io.print dots.sub(/^#{Regexp.escape(previous_results)}/, '')
             io.flush


### PR DESCRIPTION
I made the spec timeout configurable through the ´.evergreen´ files.
What's more, the error message displayed includes the file name of the spec for which the timeout was exceeded, which can be useful for debugging this error.