### PR TITLE
Implemented a Statistics class for Evergreen.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -99,7 +99,12 @@ The content of these files could look like this:
       config.public_dir = 'public_html'
       config.template_dir = 'templates'
       config.spec_dir = 'spec'
+      config.statistics_output_file = 'evergreen_run_statistics.csv'
     end
+
+Evergreen is able to gather and export to CSV statistics about the SPECS run time.
+The file to which the data is exported is set by the <tt>statistics_output_file</tt> parameter.
+If this parameter is not set, no statistics are gathered.
 
 == Transactions
 

--- a/lib/evergreen.rb
+++ b/lib/evergreen.rb
@@ -17,7 +17,7 @@ module Evergreen
   autoload :Helper, 'evergreen/helper'
 
   class << self
-    attr_accessor :driver, :root, :application, :public_dir, :spec_dir, :template_dir, :helper_dir, :mounted_at, :spec_timeout
+    attr_accessor :driver, :root, :application, :public_dir, :spec_dir, :template_dir, :helper_dir, :mounted_at, :spec_timeout, :statistics_output_file
 
     def configure
       yield self
@@ -33,6 +33,7 @@ module Evergreen
         config.helper_dir   = 'spec/javascripts/helpers'
         config.mounted_at   = ""
         config.spec_timeout = 300
+        config.statistics_output_file = nil # no statistics are gathered, if the output file is not set
       end
     end
   end

--- a/lib/evergreen/utils/statistics.rb
+++ b/lib/evergreen/utils/statistics.rb
@@ -1,0 +1,61 @@
+require 'CSV'
+
+module Evergreen
+
+  # This class gathers the statistics about the Spec run durations
+  # and writes them to a CSV file.
+  class Statistics
+
+    def initialize(output_filename)
+      @output_filename = output_filename
+      clear_output_file
+    end
+
+    # Registers the start event of a SPEC.
+    def spec_start(spec)
+      @spec_start_time = Time.now
+      @current_spec = spec
+    end
+
+    # Registers the end event of the SPEC.
+    def spec_end
+      spec_end_time = Time.now
+      duration = spec_end_time - spec_start_time
+      row = [current_spec.name, duration]
+
+      write_row(row)
+    end
+
+    private
+    attr_reader :output_filename, :spec_start_time, :current_spec
+
+    def clear_output_file
+      File.open(output_filename, 'w') {|file| file.truncate(0) }
+      #File.delete(output_filename)
+    end
+
+    def write_row(row)
+      CSV.open(output_filename, 'a') do |csv|
+        csv << row
+      end
+    end
+
+  end
+
+  # This file ignores serves as a Statistics class in case in which
+  # gathering statistics is ignored.!
+  # Using of this kind of class makes the logic easier - we don't
+  # have to use the IF statement everytime we might gather the stats.
+  class EmptyStatistics
+    def initialize(output_filename)
+    end
+
+    def spec_start(spec)
+    end
+
+    def spec_end
+    end
+  end
+
+end
+

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -27,4 +27,42 @@ describe Evergreen::Runner do
       it { is_expected.to include("2 examples, 1 failures") }
     end
   end
+
+  describe 'statistics CSV output' do
+    let(:statistics_output_file) { 'runner_spec_stat_output.csv' }
+    before :each do
+      allow(Evergreen).to receive(:statistics_output_file).and_return(statistics_output_file)
+      runner.run
+    end
+
+    after :each do
+      File.delete(statistics_output_file)
+    end
+
+    it 'creates a CSV file with statistics' do
+      csv = CSV.read(statistics_output_file)
+      expected_specs = suite.specs.map { |s| s.name }
+      specs = csv.map { |s| s[0] }
+
+      expect(specs).to match_array(expected_specs)
+    end
+  end
+
+  describe 'statistics class' do
+    subject { super().statistics.class }
+    let(:output_file) { nil }
+
+    before :each do
+      allow(Evergreen).to receive(:statistics_output_file).and_return output_file
+    end
+
+    context 'statistics are disabled' do
+      it { is_expected.to eq(Evergreen::EmptyStatistics) }
+    end
+    context 'statistics are enabled' do
+      let(:output_file) { 'some_file.csv' }
+      it { is_expected.to eq(Evergreen::Statistics) }
+    end
+  end
+
 end

--- a/spec/utils/statistics_spec.rb
+++ b/spec/utils/statistics_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'evergreen/utils/statistics'
+
+describe Evergreen::Statistics do
+  OUTPUT_FILENAME = 'evergreen_test_stats.csv'
+
+  subject { Evergreen::Statistics.new(OUTPUT_FILENAME) }
+
+  let(:statistics) do
+    [
+      ['spec_1', 56.0],
+      ['spec_2', 17.43],
+      ['spec_3', 23.11]
+    ]
+  end
+
+  def run_spec(spec_name, spec_duration)
+    spec = double(name: spec_name)
+
+    start_time = Time.new(2015,3,30, 15, 0, 0)
+    allow(Time).to receive(:now).and_return(start_time)
+    subject.spec_start(spec)
+
+    end_time = start_time + spec_duration
+    allow(Time).to receive(:now).and_return(end_time)
+    subject.spec_end
+  end
+
+  it 'writes the statistics about the specs correctly to the output file' do
+    statistics.each do |name, duration|
+      run_spec(name, duration)
+    end
+
+    row_number = 0
+    CSV.foreach(OUTPUT_FILENAME) do |csv_name, csv_duration|
+      name, duration = statistics[row_number]
+
+      expect(csv_name).to eq(name)
+      expect(csv_duration).to eq(duration.to_s)
+
+      row_number += 1
+    end
+  end
+
+  after :all do
+    File.delete(OUTPUT_FILENAME)
+  end
+
+end
+
+describe Evergreen::EmptyStatistics do
+  subject { Evergreen::EmptyStatistics.new('xyz') }
+
+  it 'has all necessary methods' do
+    expect(subject).to respond_to(:spec_start)
+    expect(subject).to respond_to(:spec_end)
+  end
+end


### PR DESCRIPTION
This class enables the developer to monitor the
time it takes to run each spec file and
export that data to a CSV file.

By default statistics gathering is disabled.
To turn it on, you need to set the `statistics_output_file` configuration.